### PR TITLE
Ensure TargetMachine has the right code model

### DIFF
--- a/compiler.cc
+++ b/compiler.cc
@@ -186,7 +186,8 @@ struct State
 				"", // cpu
 				"", // features
 				TargetOptions(),
-				Optional<Reloc::Model>());
+				Optional<Reloc::Model>(),
+				CodeModel::JITDefault);
 		if (!TM) {
 			report_fatal_error("unable to create TargetMachine");
 		}


### PR DESCRIPTION
TargetMachine defaults to CodeModel::Default, but we are using the JIT and thus should be using CodeModel::JITDefault (while it still exists), which becomes CodeModel::Large on x86_64, rather than CodeModel::Default which becomes CodeModel::Small. This fixes crashing in the JIT test cases on macOS.