### PR TITLE
Removed the optnone attribute from automaton

### DIFF
--- a/compiler.cc
+++ b/compiler.cc
@@ -113,6 +113,9 @@ struct State
 		}
 		Mod.swap(e.get());
 
+		Function *Automaton = Mod->getFunction("automaton");
+		Automaton->removeFnAttr(Attribute::OptimizeNone);
+		
 		// Get the stub (prototype) for the cell function
 		F = Mod->getFunction("cell");
 		// Set it to have private linkage, so that it can be removed after being


### PR DESCRIPTION
Since runtime.c is compiled with -O0, automaton is tagged with an optnone flag, preventing the function from being optimised after cell is inlined.